### PR TITLE
Upgrade to Bloop v1.0.0-M11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ install: scala-$(SCALA_VERSION)
 	@mkdir -p .bloop
 	@for F in $(shell ls etc); do \
 		cp etc/$$F .bloop/$$F ; \
-		sed -i 's/\$$JAVA_HOME/$(shell echo $(JAVA_HOME) | sed 's/\//\\\//g')/g' .bloop/$$F ; \
-		sed -i 's/\$$PWD/$(shell echo $(PWD) | sed 's/\//\\\//g')/g' .bloop/$$F ; \
+		sed -i.'bak' 's/\$$JAVA_HOME/$(shell echo $(JAVA_HOME) | sed 's/\//\\\//g')/g' .bloop/$$F ; \
+		sed -i.'bak' 's/\$$PWD/$(shell echo $(PWD) | sed 's/\//\\\//g')/g' .bloop/$$F ; \
 		echo "Written file $$F to $(PWD)/.bloop/" ; \
 	done
 

--- a/etc/contextual-core.json
+++ b/etc/contextual-core.json
@@ -10,18 +10,9 @@
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],
-        "classpathOptions" : {
-            "bootLibrary" : true,
-            "compiler" : false,
-            "extra" : false,
-            "autoBoot" : true,
-            "filterLibrary" : true
-        },
-        "compileOptions" : {
-            "order" : "mixed"
-        },
         "out" : "$PWD/bin",
-        "classesDir" : "$PWD/bin",
+        "classesDir" : "$PWD/bin/classes",
+        "analysisOut" : "$PWD/bin/kaleidoscope-analysis.bin",
         "scala" : {
             "organization" : "org.scala-lang",
             "name" : "scala-compiler",
@@ -31,11 +22,6 @@
             ],
             "jars" : [
                 "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar"
-            ]
-        },
-        "jvm" : {
-            "home" : "$JAVA_HOME",
-            "options" : [
             ]
         },
         "java" : {
@@ -49,6 +35,30 @@
                 "excludes" : [
                 ],
                 "arguments" : [
+                ]
+            }
+        },
+        "compileSetup" : {
+            "order" : "mixed",
+            "addLibraryToBootClasspath" : true,
+            "addCompilerToClasspath" : false,
+            "addExtraJarsToClasspath" : false,
+            "manageBootClasspath" : true,
+            "filterLibraryFromClasspath" : true
+        },
+        "resolution" : {
+            "modules": []
+        },
+        "sbt" : {
+            "sbtVersion" : "",
+            "autoImports" : [
+            ]
+        },
+        "platform" : {
+            "name" : "jvm",
+            "config" : {
+                "home" : "$JAVA_HOME",
+                "options" : [
                 ]
             }
         }

--- a/etc/contextual-data.json
+++ b/etc/contextual-data.json
@@ -10,18 +10,9 @@
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],
-        "classpathOptions" : {
-            "bootLibrary" : true,
-            "compiler" : false,
-            "extra" : false,
-            "autoBoot" : true,
-            "filterLibrary" : true
-        },
-        "compileOptions" : {
-            "order" : "mixed"
-        },
         "out" : "$PWD/bin",
-        "classesDir" : "$PWD/bin",
+        "classesDir" : "$PWD/bin/classes",
+        "analysisOut" : "$PWD/bin/kaleidoscope-analysis.bin",
         "scala" : {
             "organization" : "org.scala-lang",
             "name" : "scala-compiler",
@@ -31,11 +22,6 @@
             ],
             "jars" : [
                 "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar"
-            ]
-        },
-        "jvm" : {
-            "home" : "$JAVA_HOME",
-            "options" : [
             ]
         },
         "java" : {
@@ -49,6 +35,30 @@
                 "excludes" : [
                 ],
                 "arguments" : [
+                ]
+            }
+        },
+        "compileSetup" : {
+            "order" : "mixed",
+            "addLibraryToBootClasspath" : true,
+            "addCompilerToClasspath" : false,
+            "addExtraJarsToClasspath" : false,
+            "manageBootClasspath" : true,
+            "filterLibraryFromClasspath" : true
+        },
+        "resolution" : {
+            "modules": []
+        },
+        "sbt" : {
+            "sbtVersion" : "",
+            "autoImports" : [
+            ]
+        },
+        "platform" : {
+            "name" : "jvm",
+            "config" : {
+                "home" : "$JAVA_HOME",
+                "options" : [
                 ]
             }
         }

--- a/etc/escritoire-core.json
+++ b/etc/escritoire-core.json
@@ -10,18 +10,14 @@
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],
-        "classpathOptions" : {
-            "bootLibrary" : true,
-            "compiler" : false,
-            "extra" : false,
-            "autoBoot" : true,
-            "filterLibrary" : true
-        },
-        "compileOptions" : {
-            "order" : "mixed"
-        },
         "out" : "$PWD/bin",
-        "classesDir" : "$PWD/bin",
+        "classesDir" : "$PWD/bin/classes",
+        "analysisOut" : "$PWD/bin/kaleidoscope-analysis.bin",
+        "sbt" : {
+            "sbtVersion" : "",
+            "autoImports" : [
+            ]
+        },
         "scala" : {
             "organization" : "org.scala-lang",
             "name" : "scala-compiler",
@@ -31,11 +27,6 @@
             ],
             "jars" : [
                 "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar"
-            ]
-        },
-        "jvm" : {
-            "home" : "$JAVA_HOME",
-            "options" : [
             ]
         },
         "java" : {
@@ -49,6 +40,25 @@
                 "excludes" : [
                 ],
                 "arguments" : [
+                ]
+            }
+        },
+        "compileSetup" : {
+            "order" : "mixed",
+            "addLibraryToBootClasspath" : true,
+            "addCompilerToClasspath" : false,
+            "addExtraJarsToClasspath" : false,
+            "manageBootClasspath" : true,
+            "filterLibraryFromClasspath" : true
+        },
+        "resolution" : {
+            "modules": []
+        },
+        "platform" : {
+            "name" : "jvm",
+            "config" : {
+                "home" : "$JAVA_HOME",
+                "options" : [
                 ]
             }
         }

--- a/etc/kaleidoscope-core.json
+++ b/etc/kaleidoscope-core.json
@@ -10,18 +10,14 @@
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],
-        "classpathOptions" : {
-            "bootLibrary" : true,
-            "compiler" : false,
-            "extra" : false,
-            "autoBoot" : true,
-            "filterLibrary" : true
-        },
-        "compileOptions" : {
-            "order" : "mixed"
-        },
         "out" : "$PWD/bin",
-        "classesDir" : "$PWD/bin",
+        "classesDir" : "$PWD/bin/classes",
+        "analysisOut" : "$PWD/bin/kaleidoscope-analysis.bin",
+        "sbt" : {
+            "sbtVersion" : "",
+            "autoImports" : [
+            ]
+        },
         "scala" : {
             "organization" : "org.scala-lang",
             "name" : "scala-compiler",
@@ -31,11 +27,6 @@
             ],
             "jars" : [
                 "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar"
-            ]
-        },
-        "jvm" : {
-            "home" : "$JAVA_HOME",
-            "options" : [
             ]
         },
         "java" : {
@@ -49,6 +40,25 @@
                 "excludes" : [
                 ],
                 "arguments" : [
+                ]
+            }
+        },
+        "compileSetup" : {
+            "order" : "mixed",
+            "addLibraryToBootClasspath" : true,
+            "addCompilerToClasspath" : false,
+            "addExtraJarsToClasspath" : false,
+            "manageBootClasspath" : true,
+            "filterLibraryFromClasspath" : true
+        },
+        "resolution" : {
+            "modules": []
+        },
+        "platform" : {
+            "name" : "jvm",
+            "config" : {
+                "home" : "$JAVA_HOME",
+                "options" : [
                 ]
             }
         }

--- a/etc/kaleidoscope-test.json
+++ b/etc/kaleidoscope-test.json
@@ -10,18 +10,14 @@
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],
-        "classpathOptions" : {
-            "bootLibrary" : true,
-            "compiler" : false,
-            "extra" : false,
-            "autoBoot" : true,
-            "filterLibrary" : true
-        },
-        "compileOptions" : {
-            "order" : "mixed"
-        },
         "out" : "$PWD/bin",
-        "classesDir" : "$PWD/bin",
+        "classesDir" : "$PWD/bin/classes",
+        "analysisOut" : "$PWD/bin/kaleidoscope-analysis.bin",
+        "sbt" : {
+            "sbtVersion" : "",
+            "autoImports" : [
+            ]
+        },
         "scala" : {
             "organization" : "org.scala-lang",
             "name" : "scala-compiler",
@@ -31,11 +27,6 @@
             ],
             "jars" : [
                 "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar"
-            ]
-        },
-        "jvm" : {
-            "home" : "$JAVA_HOME",
-            "options" : [
             ]
         },
         "java" : {
@@ -49,6 +40,25 @@
                 "excludes" : [
                 ],
                 "arguments" : [
+                ]
+            }
+        },
+        "compileSetup" : {
+            "order" : "mixed",
+            "addLibraryToBootClasspath" : true,
+            "addCompilerToClasspath" : false,
+            "addExtraJarsToClasspath" : false,
+            "manageBootClasspath" : true,
+            "filterLibraryFromClasspath" : true
+        },
+        "resolution" : {
+            "modules": []
+        },
+        "platform" : {
+            "name" : "jvm",
+            "config" : {
+                "home" : "$JAVA_HOME",
+                "options" : [
                 ]
             }
         }

--- a/etc/magnolia-core.json
+++ b/etc/magnolia-core.json
@@ -10,18 +10,14 @@
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],
-        "classpathOptions" : {
-            "bootLibrary" : true,
-            "compiler" : false,
-            "extra" : false,
-            "autoBoot" : true,
-            "filterLibrary" : true
-        },
-        "compileOptions" : {
-            "order" : "mixed"
-        },
         "out" : "$PWD/bin",
-        "classesDir" : "$PWD/bin",
+        "classesDir" : "$PWD/bin/classes",
+        "analysisOut" : "$PWD/bin/kaleidoscope-analysis.bin",
+        "sbt" : {
+            "sbtVersion" : "",
+            "autoImports" : [
+            ]
+        },
         "scala" : {
             "organization" : "org.scala-lang",
             "name" : "scala-compiler",
@@ -31,11 +27,6 @@
             ],
             "jars" : [
                 "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar"
-            ]
-        },
-        "jvm" : {
-            "home" : "$JAVA_HOME",
-            "options" : [
             ]
         },
         "java" : {
@@ -49,6 +40,25 @@
                 "excludes" : [
                 ],
                 "arguments" : [
+                ]
+            }
+        },
+        "compileSetup" : {
+            "order" : "mixed",
+            "addLibraryToBootClasspath" : true,
+            "addCompilerToClasspath" : false,
+            "addExtraJarsToClasspath" : false,
+            "manageBootClasspath" : true,
+            "filterLibraryFromClasspath" : true
+        },
+        "resolution" : {
+            "modules": []
+        },
+        "platform" : {
+            "name" : "jvm",
+            "config" : {
+                "home" : "$JAVA_HOME",
+                "options" : [
                 ]
             }
         }

--- a/etc/probation-cli.json
+++ b/etc/probation-cli.json
@@ -10,18 +10,14 @@
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],
-        "classpathOptions" : {
-            "bootLibrary" : true,
-            "compiler" : false,
-            "extra" : false,
-            "autoBoot" : true,
-            "filterLibrary" : true
-        },
-        "compileOptions" : {
-            "order" : "mixed"
-        },
         "out" : "$PWD/bin",
-        "classesDir" : "$PWD/bin",
+        "classesDir" : "$PWD/bin/classes",
+        "analysisOut" : "$PWD/bin/kaleidoscope-analysis.bin",
+        "sbt" : {
+            "sbtVersion" : "",
+            "autoImports" : [
+            ]
+        },
         "scala" : {
             "organization" : "org.scala-lang",
             "name" : "scala-compiler",
@@ -31,11 +27,6 @@
             ],
             "jars" : [
                 "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar"
-            ]
-        },
-        "jvm" : {
-            "home" : "$JAVA_HOME",
-            "options" : [
             ]
         },
         "java" : {
@@ -49,6 +40,25 @@
                 "excludes" : [
                 ],
                 "arguments" : [
+                ]
+            }
+        },
+        "compileSetup" : {
+            "order" : "mixed",
+            "addLibraryToBootClasspath" : true,
+            "addCompilerToClasspath" : false,
+            "addExtraJarsToClasspath" : false,
+            "manageBootClasspath" : true,
+            "filterLibraryFromClasspath" : true
+        },
+        "resolution" : {
+            "modules": []
+        },
+        "platform" : {
+            "name" : "jvm",
+            "config" : {
+                "home" : "$JAVA_HOME",
+                "options" : [
                 ]
             }
         }

--- a/etc/probation-core.json
+++ b/etc/probation-core.json
@@ -10,18 +10,14 @@
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],
-        "classpathOptions" : {
-            "bootLibrary" : true,
-            "compiler" : false,
-            "extra" : false,
-            "autoBoot" : true,
-            "filterLibrary" : true
-        },
-        "compileOptions" : {
-            "order" : "mixed"
-        },
         "out" : "$PWD/bin",
-        "classesDir" : "$PWD/bin",
+        "classesDir" : "$PWD/bin/classes",
+        "analysisOut" : "$PWD/bin/kaleidoscope-analysis.bin",
+        "sbt" : {
+            "sbtVersion" : "",
+            "autoImports" : [
+            ]
+        },
         "scala" : {
             "organization" : "org.scala-lang",
             "name" : "scala-compiler",
@@ -31,11 +27,6 @@
             ],
             "jars" : [
                 "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar"
-            ]
-        },
-        "jvm" : {
-            "home" : "$JAVA_HOME",
-            "options" : [
             ]
         },
         "java" : {
@@ -49,6 +40,25 @@
                 "excludes" : [
                 ],
                 "arguments" : [
+                ]
+            }
+        },
+        "compileSetup" : {
+            "order" : "mixed",
+            "addLibraryToBootClasspath" : true,
+            "addCompilerToClasspath" : false,
+            "addExtraJarsToClasspath" : false,
+            "manageBootClasspath" : true,
+            "filterLibraryFromClasspath" : true
+        },
+        "resolution" : {
+            "modules": []
+        },
+        "platform" : {
+            "name" : "jvm",
+            "config" : {
+                "home" : "$JAVA_HOME",
+                "options" : [
                 ]
             }
         }

--- a/etc/probation-macros.json
+++ b/etc/probation-macros.json
@@ -10,18 +10,14 @@
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],
-        "classpathOptions" : {
-            "bootLibrary" : true,
-            "compiler" : false,
-            "extra" : false,
-            "autoBoot" : true,
-            "filterLibrary" : true
-        },
-        "compileOptions" : {
-            "order" : "mixed"
-        },
         "out" : "$PWD/bin",
-        "classesDir" : "$PWD/bin",
+        "classesDir" : "$PWD/bin/classes",
+        "analysisOut" : "$PWD/bin/kaleidoscope-analysis.bin",
+        "sbt" : {
+            "sbtVersion" : "",
+            "autoImports" : [
+            ]
+        },
         "scala" : {
             "organization" : "org.scala-lang",
             "name" : "scala-compiler",
@@ -31,11 +27,6 @@
             ],
             "jars" : [
                 "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar"
-            ]
-        },
-        "jvm" : {
-            "home" : "$JAVA_HOME",
-            "options" : [
             ]
         },
         "java" : {
@@ -49,6 +40,25 @@
                 "excludes" : [
                 ],
                 "arguments" : [
+                ]
+            }
+        },
+        "compileSetup" : {
+            "order" : "mixed",
+            "addLibraryToBootClasspath" : true,
+            "addCompilerToClasspath" : false,
+            "addExtraJarsToClasspath" : false,
+            "manageBootClasspath" : true,
+            "filterLibraryFromClasspath" : true
+        },
+        "resolution" : {
+            "modules": []
+        },
+        "platform" : {
+            "name" : "jvm",
+            "config" : {
+                "home" : "$JAVA_HOME",
+                "options" : [
                 ]
             }
         }


### PR DESCRIPTION
This PR is to upgrade bloop's configuration to v1.0.0-M11.

Also, it fixes an issue where `sed -i` doesn't work properly in MacOS