### PR TITLE
Support for non-capturing groups and regex flags

### DIFF
--- a/src/test/tests.scala
+++ b/src/test/tests.scala
@@ -98,6 +98,12 @@ object Tests extends TestApp {
     test("BigInt non-literal extraction failure") {
       scalac"""BigInt("314159") match { case i"3$${x}14159" => x }"""
     }.assert(_ == TypecheckError("kaleidoscope: only literal extractions are permitted"))
-    
+
+    test("Parse flags") {
+      "foo" match {
+        case r"(?i)$c@(foo)" => Option(c: String)
+        case _ => None
+      }
+    }.assert(_ == Some("foo"))
   }
 }


### PR DESCRIPTION
This should enhance the group-counting portion of the code enough that non-capturing groups and flags can be included in a regex now.

I wasn't able to run the code or tests as I'm in a Windows environment, but hopefully I got it right!

Fixes #14.