### PR TITLE
Setup fix, added mercator dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ bin:
 clean:
 	@rm -rf bin
 
-dependencies: ext/probation ext/magnolia ext/escritoire ext/contextual
+dependencies: ext/probation ext/magnolia ext/escritoire ext/contextual ext/mercator
 
 ext:
 	@mkdir -p ext
@@ -39,6 +39,9 @@ ext/escritoire: ext
 
 ext/contextual: ext
 	@git clone git@github.com:propensive/contextual.git --branch=fury ext/contextual
+
+ext/mercator: ext
+	@git clone git@github.com:propensive/mercator.git --branch=fury ext/mercator
 
 install: scala-$(SCALA_VERSION)
 	@which bloop >> /dev/null || (echo "Fetching bloop v1.0.0" && curl -L https://github.com/scalacenter/bloop/releases/download/v1.0.0/install.py | python)

--- a/etc/mercator-core.json
+++ b/etc/mercator-core.json
@@ -1,12 +1,12 @@
 {
     "version" : "1.0.0",
     "project" : {
-        "name" : "magnolia/core",
+        "name" : "mercator/core",
         "directory" : "$PWD",
         "sources" : [
-            "$PWD/ext/magnolia/src/core"
+            "$PWD/ext/mercator/src/core"
         ],
-        "dependencies" : ["mercator/core"],
+        "dependencies" : [],
         "classpath" : [
             "$PWD/scala-2.12.6/lib/scala-library.jar", "$PWD/scala-2.12.6/lib/scala-xml_2.12-1.0.6.jar", "$PWD/scala-2.12.6/lib/scala-compiler.jar", "$PWD/scala-2.12.6/lib/scala-reflect.jar", "$PWD/bin/"
         ],

--- a/src/test/tests.scala
+++ b/src/test/tests.scala
@@ -17,9 +17,9 @@
   the License.
 
 */
-package adversaria.tests
+package kaleidoscope.tests
 
-import probation.{TestApp, test}
+import probably.{TestApp, test}
 import contextual.data.scalac._
 import contextual.data.fqt._
 import annotation.StaticAnnotation


### PR DESCRIPTION
Considers #18, the `mercator` was missing and `probation` was renamed to `probably`.