### PR TITLE
Support date and time literals

### DIFF
--- a/src/core/datetime.scala
+++ b/src/core/datetime.scala
@@ -1,0 +1,51 @@
+/*
+
+  Kaleidoscope, version 0.2.0. Copyright 2018 Jon Pretty, Propensive Ltd.
+
+  The primary distribution site is: https://propensive.com/
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of the
+  License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+
+*/
+package kaleidoscope
+
+import contextual._
+import java.time.{LocalDate, LocalTime, LocalDateTime}
+import java.time.format.{DateTimeFormatter, DateTimeParseException}
+
+object datetime {
+  object DateParser extends Verifier[LocalDate] {
+    def check(string: String): Either[(Int, String), LocalDate] = {
+      try Right(LocalDate.parse(string))
+      catch { case e: DateTimeParseException => Left((0, "could not parse date")) }
+    }
+  }
+
+  object TimeParser extends Verifier[LocalTime] {
+    def check(string: String): Either[(Int, String), LocalTime] = {
+      try Right(LocalTime.parse(string))
+      catch { case e: DateTimeParseException => Left((0, "could not parse time")) }
+    }
+  }
+
+  object DateTimeParser extends Verifier[LocalDateTime] {
+    def check(string: String): Either[(Int, String), LocalDateTime] = {
+      try Right(LocalDateTime.parse(string))
+      catch { case e: DateTimeParseException => Left((0, "could not parse datetime")) }
+    }
+  }
+
+  implicit class DateStringContext(sc: StringContext) { val date = Prefix(DateParser, sc) }
+  implicit class TimeStringContext(sc: StringContext) { val time = Prefix(TimeParser, sc) }
+  implicit class DateTimeStringContext(sc: StringContext) { val datetime = Prefix(DateTimeParser, sc) }
+}

--- a/src/core/kaleidoscope.scala
+++ b/src/core/kaleidoscope.scala
@@ -19,6 +19,9 @@
 */
 package kaleidoscope
 
+import java.time.format.DateTimeParseException
+import java.time.{LocalDate, LocalDateTime, LocalTime}
+
 import language.experimental.macros
 import reflect._, reflect.macros._
 import java.util.regex._
@@ -146,6 +149,57 @@ private[kaleidoscope] object Macros {
       }
     }.unapply(..$args)"""
   }
+
+  def localDateUnapply(c: whitebox.Context)(scrutinee: c.Tree): c.Tree =  {
+    import c.universe._
+
+    val q"$_($_(..$partTrees)).$_.$method[..$_](..$args)" = c.macroApplication
+    val parts = partTrees.map { case lit@Literal(Constant(s: String)) => s }
+
+    if(parts.length > 1) abort(c)("only literal extractions are permitted")
+    try LocalDate.parse(parts.head)
+    catch { case e: DateTimeParseException => abort(c)("this is not a valid LocalDate") }
+
+    q"""new {
+      def unapply(input: _root_.java.time.LocalDate): _root_.scala.Boolean = {
+        input == LocalDate.parse(${parts.head})
+      }
+    }.unapply(..$args)"""
+  }
+
+  def localTimeUnapply(c: whitebox.Context)(scrutinee: c.Tree): c.Tree =  {
+    import c.universe._
+
+    val q"$_($_(..$partTrees)).$_.$method[..$_](..$args)" = c.macroApplication
+    val parts = partTrees.map { case lit@Literal(Constant(s: String)) => s }
+
+    if(parts.length > 1) abort(c)("only literal extractions are permitted")
+    try LocalTime.parse(parts.head)
+    catch { case e: DateTimeParseException => abort(c)("this is not a valid LocalTime") }
+
+    q"""new {
+      def unapply(input: _root_.java.time.LocalTime): _root_.scala.Boolean = {
+        input == LocalTime.parse(${parts.head})
+      }
+    }.unapply(..$args)"""
+  }
+
+  def localDateTimeUnapply(c: whitebox.Context)(scrutinee: c.Tree): c.Tree =  {
+    import c.universe._
+
+    val q"$_($_(..$partTrees)).$_.$method[..$_](..$args)" = c.macroApplication
+    val parts = partTrees.map { case lit@Literal(Constant(s: String)) => s }
+
+    if(parts.length > 1) abort(c)("only literal extractions are permitted")
+    try LocalDateTime.parse(parts.head)
+    catch { case e: DateTimeParseException => abort(c)("this is not a valid LocalDateTime") }
+
+    q"""new {
+      def unapply(input: _root_.java.time.LocalDateTime): _root_.scala.Boolean = {
+        input == LocalDateTime.parse(${parts.head})
+      }
+    }.unapply(..$args)"""
+  }
 }
 
 object `package` {
@@ -167,6 +221,18 @@ object `package` {
     
     object i {
       def unapply(scrutinee: BigInt): Any = macro Macros.intUnapply
+    }
+
+    object date {
+      def unapply(scrutinee: LocalDate): Any = macro Macros.localDateUnapply
+    }
+
+    object time {
+      def unapply(scrutinee: LocalTime): Any = macro Macros.localTimeUnapply
+    }
+
+    object datetime {
+      def unapply(scrutinee: LocalDateTime): Any = macro Macros.localDateTimeUnapply
     }
   }
 }

--- a/src/test/tests.scala
+++ b/src/test/tests.scala
@@ -25,6 +25,7 @@ import contextual.data.fqt._
 import annotation.StaticAnnotation
 
 import kaleidoscope._
+import java.time.{LocalDate, LocalTime, LocalDateTime}
 
 
 object Tests extends TestApp {
@@ -105,5 +106,47 @@ object Tests extends TestApp {
         case _ => None
       }
     }.assert(_ == Some("foo"))
+
+    test("Date match") {
+      LocalDate.parse("2017-02-11") match {
+        case date"2017-02-11" => 1
+        case _ => None
+      }
+    }.assert(_ == 1)
+
+    test("Time match") {
+      LocalTime.parse("12:15:06") match {
+        case time"12:15:06" => 1
+        case _ => None
+      }
+    }.assert(_ == 1)
+
+    test("Time match without seconds") {
+      LocalTime.parse("12:15") match {
+        case time"12:15" => 1
+        case _ => None
+      }
+    }.assert(_ == 1)
+
+    test("DateTime match") {
+      LocalDateTime.parse("2007-12-03T10:15:30") match {
+        case datetime"2007-12-03T10:15:30" => 1
+        case _ => None
+      }
+    }.assert(_ == 1)
+
+    test("Date invalid") {
+      scalac"""LocalDate.parse("2017-02-11") match { case date"12:15:06" => 1 }"""
+    }.assert(_ == TypecheckError("kaleidoscope: this is not a valid LocalDate"))
+
+    test("Time invalid") {
+      scalac"""LocalTime.parse("12:15:06") match { case time"2017-02-11" => true }"""
+    }.assert(_ == TypecheckError("kaleidoscope: this is not a valid LocalTime"))
+
+    test("DateTime invalid") {
+      scalac"""
+        LocalDateTime.parse("2007-12-03T10:15:30") match { case datetime"2007-12-03 10:15:30" => true }
+      """
+    }.assert(_ == TypecheckError("kaleidoscope: this is not a valid LocalDateTime"))
   }
 }


### PR DESCRIPTION
Resolves #5, simple parsing of `LocalDate`/`LocalTime` and `LocalDateTime` with `date`, `time` and `datetime` literals.